### PR TITLE
Implement API call to permanently delete (a deactivated) user

### DIFF
--- a/src/Resource/User.php
+++ b/src/Resource/User.php
@@ -381,4 +381,22 @@ class User extends Base
 
         return $request->send();
     }
+
+    /**
+     * Permanently delete a user.
+     *
+     * The user must have a status of 'DEPROVISIONED', for this to succeed.
+     *
+     * @param string $uid
+     *   An Okta user ID.
+     *
+     * @return object
+     *   Decoded API response object.
+     */
+    public function delete($uid)
+    {
+        $request = $this->request->delete('users/' . $uid);
+
+        return $request->send();
+    }
 }


### PR DESCRIPTION
Looks like the ability to make an Okta API call [1] to permanently delete a ('deactivated') user isn't currently implemented.

This PR is a change to make that possible.

[1] https://developer.okta.com/docs/api/resources/users#delete-user